### PR TITLE
Use cxx11 where needed

### DIFF
--- a/examples/ch09/01-find-package-variables/CMakeLists.txt
+++ b/examples/ch09/01-find-package-variables/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.26)
+
 project(FindPackageProtobufVariables CXX)
 
 find_package(Protobuf REQUIRED)
@@ -11,3 +12,5 @@ target_link_libraries(main PRIVATE ${Protobuf_LIBRARIES})
 target_include_directories(main PRIVATE
                                 ${Protobuf_INCLUDE_DIRS}
                                 ${CMAKE_CURRENT_BINARY_DIR})
+# Protobuf needs at least C++11
+target_compile_features(main PRIVATE cxx_std_11)


### PR DESCRIPTION
Some examples requires directly or indirectly CXX 11 support we shall add that where needed.

e.g. Protobuf requires C+11, not requiring C++11 on macOS leads to compile time errors:

```shell
/opt/local/include/google/protobuf/stubs/port.h:123:2: error: "Protobuf requires at least C++11."
#error "Protobuf requires at least C++11."
```